### PR TITLE
Allow anonymous https clone of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "yyagl"]
 	path = yyagl
-	url = git@github.com:/cflavio/yyagl
+	url = https://github.com/cflavio/yyagl
 	branch = stable


### PR DESCRIPTION
Without this change `git submodule update --init` would fail due to permission issues.